### PR TITLE
allow internal br

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -404,9 +404,11 @@ module.exports = class Flatten
       content = ''
       for child, index in tag.children
         # Allow internal line breaks
-        if child.name is 'br' and content isnt '' and index isnt tag.children.length-1
-          content += '<br>'
-          continue
+        if child.name is 'br' and content isnt ''
+          nextSibling = tag.children[index+1]
+          if nextSibling and nextSibling.name isnt 'br'
+            content += '<br>'
+            continue
         content += @tagToHtml child, id, keepCaption
       html += content
     if tag.name isnt 'img' and tag.name isnt 'source'

--- a/index.coffee
+++ b/index.coffee
@@ -402,9 +402,9 @@ module.exports = class Flatten
     html = "<#{tag.name}#{attributes}>"
     if tag.children
       content = ''
-      for child in tag.children
+      for child, index in tag.children
         # Allow internal line breaks
-        if child.name is 'br' and content isnt ''
+        if child.name is 'br' and content isnt '' and index isnt tag.children.length-1
           content += '<br>'
           continue
         content += @tagToHtml child, id, keepCaption

--- a/index.coffee
+++ b/index.coffee
@@ -402,7 +402,11 @@ module.exports = class Flatten
     html = "<#{tag.name}#{attributes}>"
     if tag.children
       content = ''
-      for child in tag.children
+      for child, index in tag.children
+        # Allow internal line breaks
+        if child.name is 'br' and content isnt ''
+          content += '<br>'
+          continue
         content += @tagToHtml child, id, keepCaption
       html += content
     if tag.name isnt 'img' and tag.name isnt 'source'

--- a/index.coffee
+++ b/index.coffee
@@ -402,7 +402,7 @@ module.exports = class Flatten
     html = "<#{tag.name}#{attributes}>"
     if tag.children
       content = ''
-      for child, index in tag.children
+      for child in tag.children
         # Allow internal line breaks
         if child.name is 'br' and content isnt ''
           content += '<br>'

--- a/spec/Flatten.coffee
+++ b/spec/Flatten.coffee
@@ -478,12 +478,12 @@ describe 'Flatten', ->
           content: [
               type: 'quote'
               html: """
-              <blockquote><p>one<br>two</p></p></blockquote>
+              <blockquote><p>one<br>two</p></blockquote>
               """
             ,
               type: 'text'
               html: """
-              <p>three<br />four</p>
+              <p>three<br>four</p>
               """
           ]
         ]

--- a/spec/Flatten.coffee
+++ b/spec/Flatten.coffee
@@ -468,6 +468,8 @@ describe 'Flatten', ->
           html: """
           <blockquote><p>one<br>two</p></blockquote>
           <p>three<br />four</p>
+          <p><br></p>
+          <ul><li>br at end<br></li></ul>
           """
         ]
 
@@ -477,14 +479,13 @@ describe 'Flatten', ->
           id: 'main'
           content: [
               type: 'quote'
-              html: """
-              <blockquote><p>one<br>two</p></blockquote>
-              """
+              html: "<blockquote><p>one<br>two</p></blockquote>"
             ,
               type: 'text'
-              html: """
-              <p>three<br>four</p>
-              """
+              html: "<p>three<br>four</p>"
+            ,
+              type: 'list'
+              html: "<ul><li>br at end</li></ul>"
           ]
         ]
 

--- a/spec/Flatten.coffee
+++ b/spec/Flatten.coffee
@@ -470,6 +470,7 @@ describe 'Flatten', ->
           <p>three<br />four</p>
           <p><br></p>
           <ul><li>br at end<br></li></ul>
+          <p>multiple<br><br>breaks</p>
           """
         ]
 
@@ -486,6 +487,9 @@ describe 'Flatten', ->
             ,
               type: 'list'
               html: "<ul><li>br at end</li></ul>"
+            ,
+              type: 'text'
+              html: "<p>multiple<br>breaks</p>"
           ]
         ]
 


### PR DESCRIPTION
The method is up for discussion, but I think it's important to maintain internal line breaks.

Doesn't break other tests, so it still strips top-level `<br>`s, and if br is first, only, last child of another element.

~~Will leave br in `<p>hello<br></p>` though. Need spec and fix if that's important to strip.~~

fixes #14
