### PR TITLE
Extract video src from children

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -211,12 +211,14 @@ module.exports = class Flatten
         video =
           type: 'video'
           html: @tagToHtml tag, id
-        if not tag.attribs.src
+        video.src = tag.attribs.poster if tag.attribs.poster
+        if tag.attribs.src
+          video.video = tag.attribs.src
+        else
           sources = {}
           for child in tag.children
             if child.name is "source" and child.attribs?.src?
               normalized = @normalizeUrl child.attribs.src, id
-              console.log child.attribs
               if child.attribs.type?
                 sources["#{child.attribs.type}"] = normalized
           if sources["video/ogv"]
@@ -225,9 +227,6 @@ module.exports = class Flatten
             video.video = sources["video/mp4"]
           else
             video.video = sources[Object.keys(sources)[0]] if (Object.keys(a)).length
-        else
-          video.video = tag.attribs.src
-        video.src = tag.attribs.poster if tag.attribs.poster
         results.push video
       when 'iframe'
         return results unless tag.attribs

--- a/index.coffee
+++ b/index.coffee
@@ -212,12 +212,19 @@ module.exports = class Flatten
           type: 'video'
           html: @tagToHtml tag, id
         if not tag.attribs.src
-          sources = []
+          sources = {}
           for child in tag.children
             if child.name is "source" and child.attribs?.src?
               normalized = @normalizeUrl child.attribs.src, id
-              sources.push normalized
-          video.video = sources if sources.length
+              console.log child.attribs
+              if child.attribs.type?
+                sources["#{child.attribs.type}"] = normalized
+          if sources["video/ogv"]
+            video.video = sources["video/ogv"]
+          else if sources["video/mp4"]
+            video.video = sources["video/mp4"]
+          else
+            video.video = sources[Object.keys(sources)[0]] if (Object.keys(a)).length
         else
           video.video = tag.attribs.src
         video.src = tag.attribs.poster if tag.attribs.poster

--- a/index.coffee
+++ b/index.coffee
@@ -211,7 +211,15 @@ module.exports = class Flatten
         video =
           type: 'video'
           html: @tagToHtml tag, id
-        video.video = tag.attribs.src if tag.attribs.src
+        if not tag.attribs.src
+          sources = []
+          for child in tag.children
+            if child.name is "source" and child.attribs?.src?
+              normalized = @normalizeUrl child.attribs.src, id
+              sources.push normalized
+          video.video = sources if sources.length
+        else
+          video.video = tag.attribs.src
         video.src = tag.attribs.poster if tag.attribs.poster
         results.push video
       when 'iframe'

--- a/spec/Flatten.coffee
+++ b/spec/Flatten.coffee
@@ -41,6 +41,10 @@ describe 'Flatten', ->
           html: '<video src="http://foo.bar/"></video>'
         ,
           type: 'video'
+          video: [
+            '//s3-us-west-2.amazonaws.com/cdn.thegrid.io/posts/cta-ui-bg.mp4',
+            '//s3-us-west-2.amazonaws.com/cdn.thegrid.io/posts/cta-ui-bg.webm'
+          ]
           html: '<video autoplay="true" loop="true" controls="false"><source type="video/mp4" src="//s3-us-west-2.amazonaws.com/cdn.thegrid.io/posts/cta-ui-bg.mp4"><source type="video/webm" src="//s3-us-west-2.amazonaws.com/cdn.thegrid.io/posts/cta-ui-bg.webm"></video>'
         ,
           type: 'hr'

--- a/spec/Flatten.coffee
+++ b/spec/Flatten.coffee
@@ -41,10 +41,7 @@ describe 'Flatten', ->
           html: '<video src="http://foo.bar/"></video>'
         ,
           type: 'video'
-          video: [
-            '//s3-us-west-2.amazonaws.com/cdn.thegrid.io/posts/cta-ui-bg.mp4',
-            '//s3-us-west-2.amazonaws.com/cdn.thegrid.io/posts/cta-ui-bg.webm'
-          ]
+          video: '//s3-us-west-2.amazonaws.com/cdn.thegrid.io/posts/cta-ui-bg.mp4'
           html: '<video autoplay="true" loop="true" controls="false"><source type="video/mp4" src="//s3-us-west-2.amazonaws.com/cdn.thegrid.io/posts/cta-ui-bg.mp4"><source type="video/webm" src="//s3-us-west-2.amazonaws.com/cdn.thegrid.io/posts/cta-ui-bg.webm"></video>'
         ,
           type: 'hr'


### PR DESCRIPTION
Extract src from children of video source tags, by creating an Object like
```
video =
  "video/mp4": "foo.mp4"
  "video/webm": "foo.webm"
```
and using only `video: "foo.mp4"` for now.